### PR TITLE
[FIX] Switch query tool port to default used by Vite

### DIFF
--- a/local_federation/docker-compose.yml
+++ b/local_federation/docker-compose.yml
@@ -14,6 +14,6 @@ services:
   query:
     image: "neurobagel/query_tool:${NB_QUERY_TAG:-latest}"
     ports:
-      - "${NB_QUERY_PORT_HOST:-3000}:3000"
+      - "${NB_QUERY_PORT_HOST:-3000}:5173"
     environment:
       - NB_API_QUERY_URL=${NB_API_QUERY_URL:-http://localhost:8000/}

--- a/local_node_with_query_tool/docker-compose.yml
+++ b/local_node_with_query_tool/docker-compose.yml
@@ -23,6 +23,6 @@ services:
   query:
     image: "neurobagel/query_tool:${NB_QUERY_TAG:-latest}"
     ports:
-      - "${NB_QUERY_PORT_HOST:-3000}:3000"
+      - "${NB_QUERY_PORT_HOST:-3000}:5173"
     environment:
       NB_API_QUERY_URL: "${NB_API_QUERY_URL:-http://localhost:8000/}"


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Related to https://github.com/neurobagel/documentation/pull/183

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Default port used by query tool container has been switched from 3000 -> 5173.

Note that we are in the process of moving to a single Compose recipe, but this change will keep our current instructions working in the interim.

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
