### PR TITLE
[FIX] Remove default `NB_API_QUERY_URL` value and fix ports used by full-stack setup script

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -58,4 +58,4 @@ services:
     ports:
       - "${NB_QUERY_PORT_HOST:-3000}:5173"
     environment:
-      NB_API_QUERY_URL: ${NB_API_QUERY_URL:-http://localhost:8000/}
+      NB_API_QUERY_URL: ${NB_API_QUERY_URL}

--- a/dev/graphdb_setup.sh
+++ b/dev/graphdb_setup.sh
@@ -128,12 +128,12 @@ echo "Environment variables have been set from ${ENV_FILE_PATH}."
 
 # Extract just the database name
 DB_NAME="${NB_GRAPH_DB#repositories/}"
-NB_GRAPH_PORT_HOST=${NB_GRAPH_PORT_HOST:-7200}
+NB_GRAPH_PORT=${NB_GRAPH_PORT:-7200}
 
 # Get the directory of this script to be able to find the data-config_template.ttl file
 SCRIPT_DIR=$(dirname "$0")
 
-echo "The GraphDB server is being accessed at http://localhost:${NB_GRAPH_PORT_HOST}."
+echo "The GraphDB server is being accessed at http://localhost:${NB_GRAPH_PORT}."
 
 ##### First time GraphDB setup #####
 
@@ -143,14 +143,14 @@ if [ "${RUN_USER_SETUP}" = "on" ]; then
     # 1. Change database admin password
     echo "Changing the admin password (note: if you have previously set the admin password, this has no effect)..."
 	# TODO: To change a *previously set* admin password, we need to also provide the current password via -u
-    curl -X PATCH --header 'Content-Type: application/json' http://localhost:${NB_GRAPH_PORT_HOST}/rest/security/users/admin -d "{\"password\": \""${ADMIN_PASS}"\"}"
+    curl -X PATCH --header 'Content-Type: application/json' http://localhost:${NB_GRAPH_PORT}/rest/security/users/admin -d "{\"password\": \""${ADMIN_PASS}"\"}"
     
 	# 2. If security is not enabled, enable it (i.e. allow only authenticated users access)
-	is_security_enabled=$(curl -s -X GET http://localhost:${NB_GRAPH_PORT_HOST}/rest/security)
+	is_security_enabled=$(curl -s -X GET http://localhost:${NB_GRAPH_PORT}/rest/security)
 	if [ "${is_security_enabled}" = "false" ]; then
 		echo "Enabling password-based access control to all databases ..."
 		# NOTE: This command fails without credentials once security is enabled
-		curl -X POST --header 'Content-Type: application/json' -d true http://localhost:${NB_GRAPH_PORT_HOST}/rest/security
+		curl -X POST --header 'Content-Type: application/json' -d true http://localhost:${NB_GRAPH_PORT}/rest/security
 	else
 		echo "Password-based access control has already been enabled."
 	fi
@@ -159,7 +159,7 @@ if [ "${RUN_USER_SETUP}" = "on" ]; then
 	# TODO: Separate this out from the first-time setup? As this can technically be run at any time to create additional users.
 	# NOTE: If user already exists, response will be "An account with the given username already exists." OK for script.
 	echo "Creating a new database user ${NB_GRAPH_USERNAME}..."
-    curl -X POST --header 'Content-Type: application/json' -u "admin:${ADMIN_PASS}" -d @- http://localhost:${NB_GRAPH_PORT_HOST}/rest/security/users/${NB_GRAPH_USERNAME} <<EOF
+    curl -X POST --header 'Content-Type: application/json' -u "admin:${ADMIN_PASS}" -d @- http://localhost:${NB_GRAPH_PORT}/rest/security/users/${NB_GRAPH_USERNAME} <<EOF
     {
         "username": "${NB_GRAPH_USERNAME}",
         "password": "${NB_GRAPH_PASSWORD}"
@@ -178,7 +178,7 @@ sed 's/rep:repositoryID "my_db" ;/rep:repositoryID "'"${DB_NAME}"'" ;/' ${SCRIPT
 # 5. Create a new database
 # Assumes data-config.ttl is in the same directory as this script!
 echo "Creating the GraphDB database ${DB_NAME}..."
-curl -X PUT -u "admin:${ADMIN_PASS}" http://localhost:${NB_GRAPH_PORT_HOST}/${NB_GRAPH_DB} --data-binary "@data-config.ttl" -H "Content-Type: application/x-turtle"
+curl -X PUT -u "admin:${ADMIN_PASS}" http://localhost:${NB_GRAPH_PORT}/${NB_GRAPH_DB} --data-binary "@data-config.ttl" -H "Content-Type: application/x-turtle"
 
 # 6. Grant newly created user access permission to the database
 # Confirm user wants to proceed with changing user permissions
@@ -193,7 +193,7 @@ curl -X PUT -u "admin:${ADMIN_PASS}" http://localhost:${NB_GRAPH_PORT_HOST}/${NB
 
 echo "Granting user ${NB_GRAPH_USERNAME} read/write permissions to database ${DB_NAME}..."
 curl -X PUT --header 'Content-Type: application/json' -d "
-{\"grantedAuthorities\": [\"WRITE_REPO_${DB_NAME}\",\"READ_REPO_${DB_NAME}\"]}" http://localhost:${NB_GRAPH_PORT_HOST}/rest/security/users/${NB_GRAPH_USERNAME} -u "admin:${ADMIN_PASS}"
+{\"grantedAuthorities\": [\"WRITE_REPO_${DB_NAME}\",\"READ_REPO_${DB_NAME}\"]}" http://localhost:${NB_GRAPH_PORT}/rest/security/users/${NB_GRAPH_USERNAME} -u "admin:${ADMIN_PASS}"
 
 echo "Done."
 

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -4,7 +4,7 @@
 GRAPHDB_PID=$!
 
 # Waiting for GraphDB to start
-while ! curl --silent "localhost:${NB_GRAPH_PORT_HOST}/rest/repositories" | grep '\[\]'; do
+while ! curl --silent "localhost:${NB_GRAPH_PORT}/rest/repositories" | grep '\[\]'; do
     :
 done
 
@@ -20,11 +20,11 @@ main() {
     echo "Finished server setup."
 
     echo "Adding datasets to the database..."
-    ./add_data_to_graph.sh ./data localhost:${NB_GRAPH_PORT_HOST} ${NB_GRAPH_DB} "${NB_GRAPH_USERNAME}" "${NB_GRAPH_PASSWORD}"
+    ./add_data_to_graph.sh ./data localhost:${NB_GRAPH_PORT} ${NB_GRAPH_DB} "${NB_GRAPH_USERNAME}" "${NB_GRAPH_PASSWORD}"
     echo "Finished adding datasets to databases."
 
     echo "Adding Neurobagel vocabulary to the database"
-    ./add_data_to_graph.sh ./vocab localhost:${NB_GRAPH_PORT_HOST} ${NB_GRAPH_DB} "${NB_GRAPH_USERNAME}" "${NB_GRAPH_PASSWORD}"
+    ./add_data_to_graph.sh ./vocab localhost:${NB_GRAPH_PORT} ${NB_GRAPH_DB} "${NB_GRAPH_USERNAME}" "${NB_GRAPH_PASSWORD}"
     echo "Finished adding the Neurobagel vocabulary to the database."
 
     echo "Finished setting up the Neurobagel graph backend."

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -13,7 +13,8 @@ SCRIPT_DIR=$(dirname "$0")
 
 # Logic for main setup
 main() {
-    echo -e "Setting up a Neurobagel graph backend...\n"
+    echo "Setting up a Neurobagel graph backend..."
+    echo -e "(The GraphDB server is being accessed inside the GraphDB container at http://localhost:${NB_GRAPH_PORT}.)\n"
 
     echo "Setting up GraphDB server..."
     ./graphdb_setup.sh "${NB_GRAPH_ADMIN_PASSWORD}"

--- a/dev/template.env
+++ b/dev/template.env
@@ -37,8 +37,8 @@ NB_FAPI_PORT_HOST=8080
 NB_FAPI_TAG=latest
 
 # ---- CONFIGURATION FOR QUERY TOOL ----
-# URL of the f-API as it will appear to a user
-NB_API_QUERY_URL=http://localhost:8080
+# URL of the n-API/f-API the query to will talk to, as it appears to a user
+NB_API_QUERY_URL=http://XX.XX.XX.XX  # REPLACE WITH YOUR API URL (AND PORT, IF APPLICABLE) AS IT APPEARS ON A USER'S MACHINE, OR localhost:<port> IF QUERY TOOL WILL ONLY BE ACCESSED FROM ITS HOST MACHINE
 # Docker image tag of the query tool (default latest)
 NB_QUERY_TAG=latest
 # Port that the query tool will be exposed on the host and likely the network (default 3000)

--- a/dev/template.env
+++ b/dev/template.env
@@ -7,8 +7,13 @@ COMPOSE_PROFILES=local_node
 
 # ---- CONFIGURATION FOR graph ----
 NB_GRAPH_ADMIN_PASSWORD=ADMINPASSWORD
-NB_GRAPH_USERNAME=DBUSER  # REPLACE DBUSER WITH YOUR GRAPH DATABASE USERNAME
-NB_GRAPH_PASSWORD=DBPASSWORD  # REPLACE DBPASSWORD WITH YOUR GRAPH DATABASE PASSWORD
+
+# **REPLACE DBUSER** with your graph database username
+NB_GRAPH_USERNAME=DBUSER
+
+# **REPLACE DBPASSWORD** with your graph database password
+NB_GRAPH_PASSWORD=DBPASSWORD
+
 NB_GRAPH_DB=repositories/my_db
 NB_RETURN_AGG=true
 NB_NAPI_TAG=latest
@@ -17,7 +22,9 @@ LOCAL_GRAPH_DATA=./data  # REPLACE WITH PATH TO YOUR JSONLD FILES
 
 # ---- CONFIGURATION FOR n-API ----
 ## ADDITIONAL CONFIGURABLE PARAMETERS: Uncomment and modify values of the below variables as needed to use non-default values.
-NB_NAPI_ALLOWED_ORIGINS="*"  # Allow multiple origins of requests. e.g. For a query tool deployed locally using default ports, use: NB_API_ALLOWED_ORIGINS="http://localhost:3000 http://127.0.0.1:3000"
+# Allow multiple origins of requests. e.g. For a query tool deployed locally using default ports, use: NB_API_ALLOWED_ORIGINS="http://localhost:3000 http://127.0.0.1:3000"
+NB_NAPI_ALLOWED_ORIGINS="*"
+
 NB_NAPI_PORT_HOST=8000
 NB_NAPI_PORT=8000
 NB_GRAPH_ROOT_HOST=~/graphdb-home
@@ -38,8 +45,12 @@ NB_FAPI_TAG=latest
 
 # ---- CONFIGURATION FOR QUERY TOOL ----
 # URL of the n-API/f-API the query to will talk to, as it appears to a user
-NB_API_QUERY_URL=http://XX.XX.XX.XX  # REPLACE WITH YOUR API URL (AND PORT, IF APPLICABLE) AS IT APPEARS ON A USER'S MACHINE, OR localhost:<port> IF QUERY TOOL WILL ONLY BE ACCESSED FROM ITS HOST MACHINE
+# **REPLACE http://XX.XX.XX.XX** with your API URL (and port, if applicable) as it appears on a user's machine, 
+# or localhost:<port> if query tool will only be accessed from its host machine
+NB_API_QUERY_URL=http://XX.XX.XX.XX
+
 # Docker image tag of the query tool (default latest)
 NB_QUERY_TAG=latest
+
 # Port that the query tool will be exposed on the host and likely the network (default 3000)
 NB_QUERY_PORT_HOST=3000


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #21 
- Closes #39 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Default value for `NB_API_QUERY_URL` removed, so this value now must always be manually provided
  - Replaced with placeholder in `template.env`
- `setup.sh` and `graphdb_setup.sh` now use the `NB_GRAPH_PORT` variable for GraphDB operations (more generic name also suits our plan to eventually have just one configurable port for GraphDB)

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
