### PR TITLE
[ENH] add auth vars to n-API & local query tool and disable by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       NB_RETURN_AGG: ${NB_RETURN_AGG:-true}
       NB_API_PORT: ${NB_NAPI_PORT:-8000}
       NB_API_ALLOWED_ORIGINS: ${NB_NAPI_ALLOWED_ORIGINS}
+      NB_ENABLE_AUTH: ${NB_ENABLE_AUTH:-false}
+      NB_QUERY_CLIENT_ID: ${NB_QUERY_CLIENT_ID}
     volumes:
       - "./scripts/api_entrypoint.sh:/usr/src/api_entrypoint.sh"
     entrypoint:
@@ -61,7 +63,7 @@ services:
     environment:
       NB_API_PORT: ${NB_FAPI_PORT:-8000}
       NB_FEDERATE_REMOTE_PUBLIC_NODES: ${NB_FEDERATE_REMOTE_PUBLIC_NODES:-True}
-      NB_ENABLE_AUTH: ${NB_ENABLE_AUTH:-true}
+      NB_ENABLE_AUTH: ${NB_ENABLE_AUTH:-false}
       NB_QUERY_CLIENT_ID: ${NB_QUERY_CLIENT_ID}
 
   query_federation:
@@ -74,7 +76,7 @@ services:
     environment:
       NB_API_QUERY_URL: ${NB_API_QUERY_URL}
       NB_IS_FEDERATION_API: "true"
-      NB_ENABLE_AUTH: ${NB_ENABLE_AUTH:-true}
+      NB_ENABLE_AUTH: ${NB_ENABLE_AUTH:-false}
       NB_QUERY_CLIENT_ID: ${NB_QUERY_CLIENT_ID}
   
   query_local:
@@ -86,6 +88,8 @@ services:
     environment:
       NB_API_QUERY_URL: ${NB_API_QUERY_URL}
       NB_IS_FEDERATION_API: "false"
+      NB_ENABLE_AUTH: ${NB_ENABLE_AUTH:-false}
+      NB_QUERY_CLIENT_ID: ${NB_QUERY_CLIENT_ID}
 
 secrets:
   db_admin_password:

--- a/docs/neurobagel_environment_variables.tsv
+++ b/docs/neurobagel_environment_variables.tsv
@@ -20,5 +20,5 @@ Environment variable	Set manually in .env?	Description	Default value if not set	
 `NB_QUERY_TAG`	No	Docker image tag for the query tool	`latest`	Docker
 `NB_QUERY_PORT_HOST`	No	Port number used by the `query_tool` on the host machine	`3000`	Docker
 `NB_FEDERATE_REMOTE_PUBLIC_NODES`	Yes 	If "True", include public nodes in federation	`true`	Docker, Python
-`NB_ENABLE_AUTH`	Yes	**(Experimental, for dev deployments only)** Whether to enable authentication for cohort queries. One of [true, false]	`true`	Docker, Python
+`NB_ENABLE_AUTH`	Yes	**(Experimental, for dev deployments only)** Whether to enable authentication for cohort queries. One of [true, false]	`false`	Docker, Python
 `NB_QUERY_CLIENT_ID`	Yes	**(Experimental, for dev deployments only)** OAuth client ID for the query tool. Required if NB_ENABLE_AUTH is set to true.	-	Docker, Python

--- a/template.env
+++ b/template.env
@@ -77,9 +77,9 @@ NB_API_QUERY_URL=http://XX.XX.XX.XX
 # --------------------------------------
 
 # ---- SECURITY CONFIGURATION ----
-# NOTE: EXPERIMENTAL, THESE SETTINGS ARE UNDER ACTIVE DEVELOPMENT AND ARE CURRENTLY FOR DEV DEPLOYMENTS ONLY.
+# NOTE: EXPERIMENTAL, THESE SETTINGS ARE UNDER ACTIVE DEVELOPMENT AND CURRENTLY SHOULD BE MODIFIED FOR DEV DEPLOYMENTS ONLY.
 # The below settings will be used for both the query tool and the f-API.
-# NB_ENABLE_AUTH=true
+# NB_ENABLE_AUTH=false
 
 # If NB_ENABLE_AUTH is set to true, you MUST provide a valid OAuth client ID for your query tool instance.
 # To obtain an OAuth client ID to enable login with Google, see https://developers.google.com/identity/openid-connect/openid-connect#appsetup.


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #66 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- n-API and local query tool (pointing to n-API) now can access auth variables
- auth disabled by default

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
