### PR TITLE
[REF] Remove container-internal ports and unneeded graph config vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,14 @@ services:
       - "local_node"
       - "full_stack"
     ports:
-      - "${NB_NAPI_PORT_HOST:-8000}:${NB_NAPI_PORT:-8000}"
+      - "${NB_NAPI_PORT_HOST:-8000}:8000"
     environment:
       NB_GRAPH_USERNAME: ${NB_GRAPH_USERNAME}
-      NB_GRAPH_ADDRESS: ${NB_GRAPH_ADDRESS:-graph}
-      NB_GRAPH_PORT: ${NB_GRAPH_PORT:-7200}
+      NB_GRAPH_ADDRESS: graph
+      NB_GRAPH_PORT: 7200
       NB_GRAPH_DB: ${NB_GRAPH_DB:-repositories/my_db}
       NB_RETURN_AGG: ${NB_RETURN_AGG:-true}
-      NB_API_PORT: ${NB_NAPI_PORT:-8000}
+      NB_API_PORT: 8000
       NB_API_ALLOWED_ORIGINS: ${NB_NAPI_ALLOWED_ORIGINS}
       NB_ENABLE_AUTH: ${NB_ENABLE_AUTH:-false}
       NB_QUERY_CLIENT_ID: ${NB_QUERY_CLIENT_ID}
@@ -25,7 +25,7 @@ services:
       - db_user_password
 
   graph:
-    image: "${NB_GRAPH_IMG:-ontotext/graphdb:10.3.1}"
+    image: "ontotext/graphdb:10.3.1"
     profiles:
       - "local_node"
       - "full_stack"
@@ -36,11 +36,11 @@ services:
       - "./vocab:/usr/src/neurobagel/vocab"
       - "${LOCAL_GRAPH_DATA:-./data}:/data"
     ports:
-      - "${NB_GRAPH_PORT_HOST:-7200}:${NB_GRAPH_PORT:-7200}"
+      - "${NB_GRAPH_PORT_HOST:-7200}:7200"
     environment:
       NB_GRAPH_USERNAME: ${NB_GRAPH_USERNAME}
-      NB_GRAPH_ADDRESS: ${NB_GRAPH_ADDRESS:-graph}
-      NB_GRAPH_PORT: ${NB_GRAPH_PORT:-7200}
+      NB_GRAPH_ADDRESS: graph
+      NB_GRAPH_PORT: 7200
       NB_GRAPH_DB: ${NB_GRAPH_DB:-repositories/my_db}
     entrypoint:
       - "/usr/src/neurobagel/scripts/setup.sh"
@@ -55,11 +55,11 @@ services:
       - "local_federation"
       - "full_stack"
     ports:
-      - "${NB_FAPI_PORT_HOST:-8080}:${NB_FAPI_PORT:-8000}"
+      - "${NB_FAPI_PORT_HOST:-8080}:8000"
     volumes:
       - "./local_nb_nodes.json:/usr/src/local_nb_nodes.json:ro"
     environment:
-      NB_API_PORT: ${NB_FAPI_PORT:-8000}
+      NB_API_PORT: 8000
       NB_FEDERATE_REMOTE_PUBLIC_NODES: ${NB_FEDERATE_REMOTE_PUBLIC_NODES:-True}
       NB_ENABLE_AUTH: ${NB_ENABLE_AUTH:-false}
       NB_QUERY_CLIENT_ID: ${NB_QUERY_CLIENT_ID}

--- a/docs/neurobagel_environment_variables.tsv
+++ b/docs/neurobagel_environment_variables.tsv
@@ -9,14 +9,9 @@ Environment variable	Set manually in .env?	Description	Default value if not set	
 `NB_RETURN_AGG`	Yes	Whether to return only aggregate, dataset-level query results (excluding subject/session-level attributes). One of [true, false]	`true`	Docker, Python
 `NB_NAPI_TAG`	No	Docker image tag for the Neurobagel node API	`latest`	Docker
 `NB_NAPI_PORT_HOST`	No	Port number on the _host machine_ to map the Neurobagel node API container port to	`8000`	Docker
-`NB_NAPI_PORT`	No	Port number on which to run the Neurobagel node API _in the API container_	`8000`	Docker
 `NB_FAPI_TAG`	No	Docker image tag for the Neurobagel federation API	`latest`	Docker
 `NB_FAPI_PORT_HOST`	No	Port number on the _host machine_ to map the Neurobagel federation API container port to	`8080`	Docker
-`NB_FAPI_PORT`	No	Port number on which to run the Neurobagel federation API _in the API container_	`8000`	Docker
-`NB_GRAPH_IMG`	No	Graph server Docker image	`ontotext/graphdb:10.3.1`	Docker
-`NB_GRAPH_ADDRESS`	No	IP address for the graph database (or container name, if graph is hosted locally)	`206.12.99.17 (graph)` **	Docker, Python
 `NB_GRAPH_PORT_HOST`	No	Port number on the _host machine_ to map the graph server container port to	`7200`	Docker
-`NB_GRAPH_PORT`	No	Port number used by the _graph server container_	`7200` *	Docker, Python
 `NB_QUERY_TAG`	No	Docker image tag for the query tool	`latest`	Docker
 `NB_QUERY_PORT_HOST`	No	Port number used by the `query_tool` on the host machine	`3000`	Docker
 `NB_FEDERATE_REMOTE_PUBLIC_NODES`	Yes 	If "True", include public nodes in federation. If "False", only locally specified nodes in `local_nb_nodes.json` are queried.	`true`	Docker, Python

--- a/template.env
+++ b/template.env
@@ -32,9 +32,6 @@ LOCAL_GRAPH_DATA=./data
 # Additional configurable parameters - uncomment to change the defaults
 # Change NB_GRAPH_PORT_HOST if port 7200 is already in use on the machine
 # NB_GRAPH_PORT_HOST=7200
-# NB_GRAPH_PORT=7200
-# NB_GRAPH_IMG=ontotext/graphdb:10.3.1
-# NB_GRAPH_ADDRESS=graph
 # ---------------------------------
 
 # ---- CONFIGURATION FOR n-API ----
@@ -46,7 +43,6 @@ NB_RETURN_AGG=true
 # Additional configurable parameters - uncomment to change the defaults
 # Change NB_NAPI_PORT_HOST if port 8000 is already in use on the machine
 # NB_NAPI_PORT_HOST=8000
-# NB_NAPI_PORT=8000
 # NB_NAPI_TAG=latest
 # ---------------------------------
 
@@ -54,7 +50,6 @@ NB_RETURN_AGG=true
 # Additional configurable parameters - uncomment to change the defaults
 # Change NB_FAPI_PORT_HOST if port 8080 is already in use on the machine
 # NB_FAPI_PORT_HOST=8080
-# NB_FAPI_PORT=8000
 # NB_FAPI_TAG=latest
 # NB_FEDERATE_REMOTE_PUBLIC_NODES=True
 # ---------------------------------


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #30
- Related: https://github.com/neurobagel/recipes/issues/81

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- The following variables have been removed as .env-configurable options and now have hardcoded values in docker-compose.yml:
  1. `NB_GRAPH_ADDRESS`
  2. `NB_GRAPH_PORT` *
  3. `NB_GRAPH_IMG`
  4. `NB_NAPI_PORT` *
  5. `NB_FAPI_PORT` *

(*) Note that the *container* `environment` variables corresponding to these options still exist and are still expected/used by scripts within the Compose stack, their port values are just now hardcoded in the container environment
  - e.g., setup.sh for the graph looks for the value of an `NB_GRAPH_PORT` env var; the n-API will use `NB_API_PORT` from the container environment to determine what port to launch uvicorn on

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
