### PR TITLE
[FIX] Fix syntax error in setup.sh with setting the GraphDB memory limit (`NB_GRAPH_MEMORY`)

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,9 +2,9 @@
 
 if [[ -z "${NB_GRAPH_MEMORY}" ]]; then
     echo "NB_GRAPH_MEMORY is not set. Defaulting to 2G."
-    temp_GRAPH_MEM = "-Xmx2G"
+    temp_GRAPH_MEM="-Xmx2G"
 else
-    temp_GRAPH_MEM = "-Xmx${NB_GRAPH_MEMORY}"
+    temp_GRAPH_MEM="-Xmx${NB_GRAPH_MEMORY}"
 fi
 
 /opt/graphdb/dist/bin/graphdb -Dgraphdb.home=/opt/graphdb/home ${temp_GRAPH_MEM} &


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Related: https://github.com/neurobagel/recipes/issues/49

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- There are currently spaces in the variable assignment for `temp_GRAPH_MEM` which are not allowed, as a result `NB_GRAPH_MEMORY` has no effect, and neither does the default

Container logs:
```bash
alyssa@fabrique:~/admin/projects/douglas_asmq_temp_node/scripts$ docker logs asmq_node-graph-1
NB_GRAPH_MEMORY is not set. Defaulting to 2G.
/usr/src/neurobagel/scripts/setup.sh: line 5: temp_GRAPH_MEM: command not found
...
```
- Notably, b/c `setup.sh` doesn't exit on unexpected errors/unset vars, it keeps running even though `temp_GRAPH_MEM` is not found

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
