### PR TITLE
[ENH] Support catalog mode that parses only data dict and dataset description files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     volumes:
       - "${LOCAL_GRAPH_DATA:-./data}:/input_data"
       - "neurobagel_data:/data"
+    environment:
+      NB_CATALOG_MODE: ${NB_CATALOG_MODE:-false}
     command: >
       sh -euxc "rm -rf /data/* && python -m init_data.process_jsonld /input_data /data"
 
@@ -30,6 +32,7 @@ services:
       NB_ENABLE_AUTH: ${NB_ENABLE_AUTH:-false}
       NB_QUERY_CLIENT_ID: ${NB_QUERY_CLIENT_ID}
       NB_CONFIG: ${NB_CONFIG:-Neurobagel}
+      NB_CATALOG_MODE: ${NB_CATALOG_MODE:-false}
     volumes:
       - "./scripts/api_entrypoint.sh:/usr/src/api_entrypoint.sh"
       - "neurobagel_data:/data"

--- a/init_data/process_jsonld.py
+++ b/init_data/process_jsonld.py
@@ -218,10 +218,12 @@ def get_dataset_level_pheno_attributes(data_dict: dict, dataset_name: str) -> di
 
 def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) -> dict:
     """
-    Validate and extract dataset-level metadata from all Neurobagel dataset JSONLD files in a directory.
-    
-    Validated JSONLD files are copied to the output directory,
-    and a dictionary mapping dataset UUIDs to their metadata is returned.
+    Validate and extract dataset-level metadata from all Neurobagel dataset files in a directory, either:
+    - dataset JSONLD files in subject-level mode, or
+    - pairs of dataset description and data dictionary JSON files in catalog mode
+
+    In subject-level node mode, validated JSONLD files are copied to the output directory.
+    A dictionary mapping dataset UUIDs to their metadata is returned.
     """    
     datasets_metadata_lookup = {}
     excluded_jsonlds = []

--- a/init_data/process_jsonld.py
+++ b/init_data/process_jsonld.py
@@ -43,21 +43,6 @@ jsonld_key_to_dataset_attribute_mapping = {
     "hasPortalURI": "access_link",  # Map legacy hasPortalURI to access_link
 }
 
-json_key_to_dataset_attribute_mapping = {
-    "Name": "dataset_name",  # required
-    "Authors": "authors",
-    "ParticipantCount": "participant_count",  # required
-    "ReferencesAndLinks": "references_and_links",
-    "Keywords": "keywords",
-    "RepositoryURL": "repository_url",
-    "AccessInstructions": "access_instructions",
-    "AccessType": "access_type",
-    "AccessEmail": "access_email",
-    "AccessLink": "access_link",
-}
-
-# participant_count
-# range: minimum, maximum
 
 def load_json(path: Path) -> dict:
     """Load a JSON file and return its content as a dictionary."""
@@ -127,6 +112,9 @@ def get_is_part_of_assessment(column_annotations: dict) -> str:
 
 
 def transform_age(value: str, value_format: str) -> float | None:
+    """
+    Adapted from: https://github.com/neurobagel/bagel-cli/blob/053f9c87e1030392158d0975759c955c24199a3c/bagel/utilities/pheno_utils.py#L226-L259.
+    """
     try:
         if value_format in [
             AGE_FORMATS["float"],
@@ -161,7 +149,7 @@ def transform_age(value: str, value_format: str) -> float | None:
     return None
 
 
-def get_summary_pheno_attributes(data_dict: dict, dataset_name: str) -> dict | None:
+def get_summary_pheno_attributes_for_dataset(data_dict: dict, dataset_name: str) -> dict | None:
     summary_pheno_attributes = {}
 
     sex_column_annotations = get_column_annotations_about(data_dict, "nb:Sex")
@@ -191,9 +179,9 @@ def get_summary_pheno_attributes(data_dict: dict, dataset_name: str) -> dict | N
     summary_pheno_attributes = {
         variable: list(dict.fromkeys(terms)) for variable, terms in summary_pheno_attributes.items()
     }
-    
-    # TODO: Handle age
+
     age_column_annotations = get_column_annotations_about(data_dict, "nb:Age")
+    # Keep handling of >1 age columns consistent with the CLI
     if len(age_column_annotations) > 1:
         logger.warning(
             f"Dataset '{dataset_name}': The data dictionary indicates more than one column about age, "
@@ -210,12 +198,12 @@ def get_summary_pheno_attributes(data_dict: dict, dataset_name: str) -> dict | N
                 f"Dataset '{dataset_name}': Unable to transform the minimum and/or maximum age values to floats. "
             )
             return None
-
         summary_pheno_attributes["age_range"] = {
             "minimum": transformed_min,
             "maximum": transformed_max,
         }
     else:
+        # Or, should we just omit the key altogether?
         summary_pheno_attributes["age_range"] = None
 
     return summary_pheno_attributes
@@ -241,10 +229,9 @@ def extract_datasets_metadata_to_dict(jsonld_dir: Path, output_dir: Path) -> dic
             elif json_file.name.endswith(DATASET_DESCRIPTION_SUFFIX):
                 dataset_id = json_file.name.removesuffix(DATASET_DESCRIPTION_SUFFIX)
                 dataset_file_groups[dataset_id]["description"] = json_file
-        
-        dataset_file_pairs = {}
+
         for dataset_file_id, dataset_files in dataset_file_groups.items():
-            # or, just check based on length
+            # TODO: Switch to checking just based on length?
             if "dictionary" not in dataset_files or "description" not in dataset_files:
                 file = dataset_files.get("dictionary") or dataset_files.get("description")
                 if "dictionary" not in dataset_files:
@@ -273,19 +260,21 @@ def extract_datasets_metadata_to_dict(jsonld_dir: Path, output_dir: Path) -> dic
                 continue
 
             # dump back to dict
-            validated_dataset_desc = validated_dataset_desc.model_dump()
-            dataset_name = validated_dataset_desc["dataset_name"]
-
-            if homepage_url := get_homepage_url(validated_dataset_desc["references_and_links"]):
+            # TODO: Rename to 'validated_dataset_desc'?
+            dataset_attributes = validated_dataset_desc.model_dump()
+            if homepage_url := get_homepage_url(dataset_attributes["references_and_links"]):
                 dataset_attributes["homepage"] = homepage_url
-            
-            dataset_summary_pheno_attributes = get_summary_pheno_attributes(data_dict, dataset_name)
+
+            dataset_name = dataset_attributes["dataset_name"]
+            dataset_summary_pheno_attributes = get_summary_pheno_attributes_for_dataset(data_dict, dataset_name)
             if dataset_summary_pheno_attributes is None:
                 logger.error(
-                    f"Dataset '{dataset_name}': Unable to extract summary phenotypic attributes from the data dictionary. Skipping dataset."
+                    f"Dataset '{dataset_name}': "
+                    "Failed to extract summary phenotypic attributes from the data dictionary. "
+                    "Skipping dataset."
                 )
                 continue
-            dataset_attributes = {**validated_dataset_desc, **dataset_summary_pheno_attributes}
+            dataset_attributes = {**dataset_attributes, **dataset_summary_pheno_attributes}
 
     else:
         num_input_jsonlds = len(list(jsonld_dir.glob("*.jsonld")))

--- a/init_data/process_jsonld.py
+++ b/init_data/process_jsonld.py
@@ -151,7 +151,11 @@ def transform_age(value: str, value_format: str) -> float | None:
     return None
 
 
-def get_summary_pheno_attributes_for_dataset(data_dict: dict, dataset_name: str) -> dict | None:
+def get_dataset_level_pheno_attributes(data_dict: dict, dataset_name: str) -> dict | None:
+    """
+    Extract dataset-level sex, diagnosis, assessment, and age range info from the data dictionary annotations
+    for catalog mode purposes.
+    """
     summary_pheno_attributes = {}
 
     sex_column_annotations = get_column_annotations_about(data_dict, "nb:Sex")
@@ -212,8 +216,7 @@ def get_summary_pheno_attributes_for_dataset(data_dict: dict, dataset_name: str)
     return summary_pheno_attributes
 
 
-# TODO: Rename jsonld_dir to data_dir to account for fact that it'll have JSONs as well
-def extract_datasets_metadata_to_dict(jsonld_dir: Path, output_dir: Path) -> dict:
+def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) -> dict:
     """
     Validate and extract dataset-level metadata from all Neurobagel dataset JSONLD files in a directory.
     
@@ -224,17 +227,25 @@ def extract_datasets_metadata_to_dict(jsonld_dir: Path, output_dir: Path) -> dic
     excluded_jsonlds = []
 
     if NB_CATALOG_MODE:
-        dataset_file_groups = defaultdict(dict)
-        for json_file in jsonld_dir.glob("*.json"):
+        dataset_json_file_groups = defaultdict(dict)
+        skipped_json_files = []
+        for json_file in data_files_dir.glob("*.json"):
             if json_file.name.endswith(DATA_DICTIONARY_SUFFIX):
                 dataset_id = json_file.name.removesuffix(DATA_DICTIONARY_SUFFIX)
-                dataset_file_groups[dataset_id]["dictionary"] = json_file
+                dataset_json_file_groups[dataset_id]["dictionary"] = json_file
             elif json_file.name.endswith(DATASET_DESCRIPTION_SUFFIX):
                 dataset_id = json_file.name.removesuffix(DATASET_DESCRIPTION_SUFFIX)
-                dataset_file_groups[dataset_id]["description"] = json_file
+                dataset_json_file_groups[dataset_id]["description"] = json_file
+            else:
+                logger.warning(
+                    f"JSON file {json_file.name} does not have the expected suffix "
+                    f"for a data dictionary ({DATA_DICTIONARY_SUFFIX}) "
+                    f"or a dataset description ({DATASET_DESCRIPTION_SUFFIX}). "
+                    "Skipping file."
+                )
+                skipped_json_files.append(json_file.name)
 
-        for dataset_file_id, dataset_files in dataset_file_groups.items():
-            # TODO: Switch to checking just based on length?
+        for dataset_file_id, dataset_files in dataset_json_file_groups.items():
             if "dictionary" not in dataset_files or "description" not in dataset_files:
                 file = dataset_files.get("dictionary") or dataset_files.get("description")
                 if "dictionary" not in dataset_files:
@@ -242,24 +253,24 @@ def extract_datasets_metadata_to_dict(jsonld_dir: Path, output_dir: Path) -> dic
                 else:
                     missing_file = f"{dataset_file_id}{DATASET_DESCRIPTION_SUFFIX}"
                 logger.error(
-                    f"{file}' is missing a corresponding {missing_file}. Skipping dataset."
+                    f"{file.name} is missing a corresponding {missing_file}. Skipping dataset."
                 )
+                skipped_json_files.append(file.name)
                 continue
 
             # TODO: Validate the data dict
             data_dict = load_json(dataset_files["dictionary"])
             dataset_desc = load_json(dataset_files["description"])
-            # TODO: Generate a UUID programmatically
-
             try:
                 validated_dataset_desc = dataset_description_model.DatasetDescription.model_validate(dataset_desc)
             except ValidationError as err:
                 logger.error(
-                    f"{dataset_files['description']} is not a invalid Neurobagel dataset description. "
+                    f"{dataset_files['description'].name} is not a valid Neurobagel dataset description. "
                     "Skipping dataset."
                     f"\nValidation details:\n"
                     f"{err}",
                 )
+                skipped_json_files.extend([dataset_files["description"].name, dataset_files["dictionary"].name])
                 continue
 
             # dump back to dict
@@ -269,19 +280,25 @@ def extract_datasets_metadata_to_dict(jsonld_dir: Path, output_dir: Path) -> dic
 
             dataset_name = validated_dataset_desc["dataset_name"]
             dataset_uuid = "nb:" + str(uuid.uuid4())
-            dataset_summary_pheno_attributes = get_summary_pheno_attributes_for_dataset(data_dict, dataset_name)
+            dataset_summary_pheno_attributes = get_dataset_level_pheno_attributes(data_dict, dataset_name)
             if dataset_summary_pheno_attributes is None:
                 logger.error(
                     f"Dataset '{dataset_name}': "
                     "Failed to extract summary phenotypic attributes from the data dictionary. "
                     "Skipping dataset."
                 )
+                skipped_json_files.extend([dataset_files["description"].name, dataset_files["dictionary"].name])
                 continue
             dataset_attributes =  {**validated_dataset_desc, **dataset_summary_pheno_attributes}
             datasets_metadata_lookup[dataset_uuid] = dataset_attributes
+        
+        logger.info(
+            f"Dataset metadata successfully parsed from {len(datasets_metadata_lookup)} datasets for catalog mode. "
+            f"Excluded {len(skipped_json_files)} JSON files:\n" + "\n".join(skipped_json_files)
+        )
     else:
-        num_input_jsonlds = len(list(jsonld_dir.glob("*.jsonld")))
-        for idx, jsonld_path in enumerate(jsonld_dir.glob("*.jsonld"), start=1):
+        num_input_jsonlds = len(list(data_files_dir.glob("*.jsonld")))
+        for idx, jsonld_path in enumerate(data_files_dir.glob("*.jsonld"), start=1):
             filename = jsonld_path.name
             logger.info(f"({idx}/{num_input_jsonlds}) Processing file: {filename}")
             jsonld_dataset = load_and_validate_jsonld_dataset(jsonld_path)

--- a/init_data/process_jsonld.py
+++ b/init_data/process_jsonld.py
@@ -5,7 +5,7 @@ import logging
 import argparse
 import shutil
 from pydantic import ValidationError, TypeAdapter, HttpUrl
-from init_data.utils import models
+from init_data.utils import models, dataset_description_model
 from collections import defaultdict
 
 NB_CATALOG_MODE = os.environ.get("NB_CATALOG_MODE", "false").lower() == "true"
@@ -112,6 +112,7 @@ def extract_datasets_metadata_to_dict(jsonld_dir: Path, output_dir: Path) -> dic
         
         dataset_file_pairs = {}
         for dataset_file_id, dataset_files in dataset_file_groups.items():
+            # or, just check based on length
             if "dictionary" not in dataset_files or "description" not in dataset_files:
                 file = dataset_files.get("dictionary") or dataset_files.get("description")
                 if "dictionary" not in dataset_files:
@@ -124,12 +125,16 @@ def extract_datasets_metadata_to_dict(jsonld_dir: Path, output_dir: Path) -> dic
                 continue
 
             data_dict = load_json(dataset_files["dictionary"])
-            dataset_description = load_json(dataset_files["description"])
+            dataset_desc = load_json(dataset_files["description"])
             # TODO: Generate a UUID programmatically
 
+            validated_dataset_desc = dataset_description_model.DatasetDescription.model_validate(dataset_desc)
+
             for dataset_description_key in json_key_to_dataset_attribute_mapping:
-                if dataset_description_key in dataset_description:
-                    pass
+                if dataset_description_key in validated_dataset_desc:
+                    if dataset_description_key == "ReferencesAndLinks":
+                        if homepage_url := get_homepage_url(validated_dataset_desc[dataset_description_key]):
+                            dataset_attributes["homepage"] = homepage_url
 
     else:
         num_input_jsonlds = len(list(jsonld_dir.glob("*.jsonld")))

--- a/init_data/process_jsonld.py
+++ b/init_data/process_jsonld.py
@@ -87,6 +87,7 @@ def get_homepage_url(references_and_links: list[str]) -> str | None:
 
 
 def get_all_column_annotations(data_dict: dict) -> list[dict]:
+    """Return a list of all column Neurobagel annotations in the data dictionary."""
     return [
         column_content["Annotations"]
         for column_content in data_dict.values()
@@ -95,6 +96,7 @@ def get_all_column_annotations(data_dict: dict) -> list[dict]:
 
 
 def get_column_annotations_about(data_dict: dict, std_var: str) -> list[dict]:
+    """Return a list of Neurobagel annotations for all columns about a specific standardized variable."""
     return [
         column_annotations for column_annotations in get_all_column_annotations(data_dict)
         if column_annotations["IsAbout"]["TermURL"] == std_var
@@ -102,6 +104,7 @@ def get_column_annotations_about(data_dict: dict, std_var: str) -> list[dict]:
 
 
 def get_categorical_annotations_levels(column_annotations: dict) -> list[str]:
+    """Return a list of the standardized terms corresponding to the levels of a categorical variable."""
     levels_std_terms = []
     for level in column_annotations["Levels"].values():
         levels_std_terms.append(level["TermURL"])
@@ -110,6 +113,8 @@ def get_categorical_annotations_levels(column_annotations: dict) -> list[str]:
 
 def transform_age(value: str, value_format: str) -> float | None:
     """
+    Transform raw age value to a float based on the annotated format.
+
     Adapted from: https://github.com/neurobagel/bagel-cli/blob/053f9c87e1030392158d0975759c955c24199a3c/bagel/utilities/pheno_utils.py#L226-L259.
     """
     try:
@@ -173,6 +178,7 @@ def get_summary_pheno_attributes_for_dataset(data_dict: dict, dataset_name: str)
         available_assessments.append(assessment_column["IsPartOf"]["TermURL"])
     summary_pheno_attributes["available_assessments"] = available_assessments
 
+    # Ensure that lists of variable instances are unique
     summary_pheno_attributes = {
         variable: list(dict.fromkeys(terms)) for variable, terms in summary_pheno_attributes.items()
     }

--- a/init_data/process_jsonld.py
+++ b/init_data/process_jsonld.py
@@ -47,6 +47,10 @@ jsonld_key_to_dataset_attribute_mapping = {
 
 
 def list_files_with_extension(input_dir: Path, extension: str) -> list[Path]:
+    """
+    Get a list of all files in the input directory with the specified extension
+    and log an error if no such files are found.
+    """
     file_list = list(input_dir.glob(f"*{extension}"))
     if not file_list:
         logger.error(
@@ -271,7 +275,9 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
                 else:
                     missing_file = f"{dataset_file_id}{DATASET_DESCRIPTION_SUFFIX}"
                 logger.error(
-                    f"{file.name} is missing a corresponding {missing_file}. Skipping dataset."
+                    f"{file.name} is missing a corresponding {missing_file}. "
+                    "Ensure that the data dictionary and dataset description files for the dataset have the same prefix. "
+                    "Skipping dataset."
                 )
                 excluded_jsons.append(file.name)
                 continue
@@ -383,17 +389,17 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
 def parse_arguments():
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
-        description="Validate and extract dataset-level metadata from Neurobagel dataset JSONLD files."
+        description="Validate and extract dataset-level metadata from Neurobagel dataset JSON(LD) files."
     )
     parser.add_argument(
         "input_dir",
         type=lambda p: Path(p).resolve(),
-        help="Directory containing Neurobagel dataset JSONLD files."
+        help="Directory containing Neurobagel dataset JSON or JSONLD files."
     )
     parser.add_argument(
         "output_dir",
         type=lambda p: Path(p).resolve(),
-        help="Directory to save validated JSONLD files and dataset metadata JSON file."
+        help="Directory to save validated JSONLD files and/or dataset metadata JSON file."
     )
     return parser.parse_args()
     

--- a/init_data/process_jsonld.py
+++ b/init_data/process_jsonld.py
@@ -1,3 +1,4 @@
+import os
 import json
 from pathlib import Path
 import logging
@@ -5,6 +6,11 @@ import argparse
 import shutil
 from pydantic import ValidationError, TypeAdapter, HttpUrl
 from init_data.utils import models
+from collections import defaultdict
+
+NB_CATALOG_MODE = os.environ.get("NB_CATALOG_MODE", "false").lower() == "true"
+DATA_DICTIONARY_SUFFIX = "_annotated.json"
+DATASET_DESCRIPTION_SUFFIX = "_dataset_description.json"
 
 logging.basicConfig(
     level=logging.INFO,
@@ -27,9 +33,24 @@ jsonld_key_to_dataset_attribute_mapping = {
     "hasPortalURI": "access_link",  # Map legacy hasPortalURI to access_link
 }
 
+json_key_to_dataset_attribute_mapping = {
+    "Name": "dataset_name",  # required
+    "Authors": "authors",
+    "ParticipantCount": "participant_count",  # required
+    "ReferencesAndLinks": "references_and_links",
+    "Keywords": "keywords",
+    "RepositoryURL": "repository_url",
+    "AccessInstructions": "access_instructions",
+    "AccessType": "access_type",
+    "AccessEmail": "access_email",
+    "AccessLink": "access_link",
+}
 
-def load_jsonld(path: Path) -> dict:
-    """Load a JSONLD file and return its content as a dictionary."""
+# participant_count
+# range: minimum, maximum
+
+def load_json(path: Path) -> dict:
+    """Load a JSON file and return its content as a dictionary."""
     with open(path, "r", encoding="utf-8") as f:
         return json.load(f)
 
@@ -38,7 +59,7 @@ def load_and_validate_jsonld_dataset(file_path: Path) -> dict | None:
     """
     Strip the @context from the contents of a JSONLD file and validate it against the Neurobagel Dataset model.
     """
-    jsonld = load_jsonld(file_path)
+    jsonld = load_json(file_path)
     jsonld.pop("@context")
     try:
         models.Dataset.model_validate(jsonld)
@@ -68,7 +89,7 @@ def get_homepage_url(references_and_links: list[str]) -> str | None:
         None
     )
 
-
+# TODO: Rename jsonld_dir to data_dir to account for fact that it'll have JSONs as well
 def extract_datasets_metadata_to_dict(jsonld_dir: Path, output_dir: Path) -> dict:
     """
     Validate and extract dataset-level metadata from all Neurobagel dataset JSONLD files in a directory.
@@ -79,30 +100,62 @@ def extract_datasets_metadata_to_dict(jsonld_dir: Path, output_dir: Path) -> dic
     datasets_metadata_lookup = {}
     excluded_jsonlds = []
 
-    num_input_jsonlds = len(list(jsonld_dir.glob("*.jsonld")))
-    for idx, jsonld_path in enumerate(jsonld_dir.glob("*.jsonld"), start=1):
-        filename = jsonld_path.name
-        logger.info(f"({idx}/{num_input_jsonlds}) Processing file: {filename}")
-        dataset = load_and_validate_jsonld_dataset(jsonld_path)
-        if dataset is None:
-            excluded_jsonlds.append(filename)
-            continue
+    if NB_CATALOG_MODE:
+        dataset_file_groups = defaultdict(dict)
+        for json_file in jsonld_dir.glob("*.json"):
+            if json_file.name.endswith(DATA_DICTIONARY_SUFFIX):
+                dataset_id = json_file.name.removesuffix(DATA_DICTIONARY_SUFFIX)
+                dataset_file_groups[dataset_id]["dictionary"] = json_file
+            elif json_file.name.endswith(DATASET_DESCRIPTION_SUFFIX):
+                dataset_id = json_file.name.removesuffix(DATASET_DESCRIPTION_SUFFIX)
+                dataset_file_groups[dataset_id]["description"] = json_file
+        
+        dataset_file_pairs = {}
+        for dataset_file_id, dataset_files in dataset_file_groups.items():
+            if "dictionary" not in dataset_files or "description" not in dataset_files:
+                file = dataset_files.get("dictionary") or dataset_files.get("description")
+                if "dictionary" not in dataset_files:
+                    missing_file = f"{dataset_file_id}{DATA_DICTIONARY_SUFFIX}"
+                else:
+                    missing_file = f"{dataset_file_id}{DATASET_DESCRIPTION_SUFFIX}"
+                logger.warning(
+                    f"{file}' is missing a corresponding {missing_file}. Skipping dataset."
+                )
+                continue
 
-        dataset_uuid = dataset["identifier"]
-        dataset_attributes = {}
-        for jsonld_key, attribute_name in jsonld_key_to_dataset_attribute_mapping.items():
-            if jsonld_key in dataset:
-                if jsonld_key == "hasReferencesAndLinks":
-                    if homepage_url := get_homepage_url(dataset[jsonld_key]):
-                        dataset_attributes["homepage"] = homepage_url
-                elif jsonld_key == "hasPortalURI":
-                    logger.warning(
-                        f"{filename} uses a deprecated dataset-level 'hasPortalURI' key. "
-                        "This URL will be stored as the access link for the dataset instead. "
-                        "We recommend updating your JSONLD using the latest version of the Neurobagel CLI."
-                    )
-                dataset_attributes[attribute_name] = dataset[jsonld_key]
-        datasets_metadata_lookup[dataset_uuid] = dataset_attributes
+            data_dict = load_json(dataset_files["dictionary"])
+            dataset_description = load_json(dataset_files["description"])
+            # TODO: Generate a UUID programmatically
+
+            for dataset_description_key in json_key_to_dataset_attribute_mapping:
+                if dataset_description_key in dataset_description:
+                    pass
+
+    else:
+        num_input_jsonlds = len(list(jsonld_dir.glob("*.jsonld")))
+        for idx, jsonld_path in enumerate(jsonld_dir.glob("*.jsonld"), start=1):
+            filename = jsonld_path.name
+            logger.info(f"({idx}/{num_input_jsonlds}) Processing file: {filename}")
+            jsonld_dataset = load_and_validate_jsonld_dataset(jsonld_path)
+            if jsonld_dataset is None:
+                excluded_jsonlds.append(filename)
+                continue
+
+            dataset_uuid = jsonld_dataset["identifier"]
+            dataset_attributes = {}
+            for jsonld_key, attribute_name in jsonld_key_to_dataset_attribute_mapping.items():
+                if jsonld_key in jsonld_dataset:
+                    if jsonld_key == "hasReferencesAndLinks":
+                        if homepage_url := get_homepage_url(jsonld_dataset[jsonld_key]):
+                            dataset_attributes["homepage"] = homepage_url
+                    elif jsonld_key == "hasPortalURI":
+                        logger.warning(
+                            f"{filename} uses a deprecated dataset-level 'hasPortalURI' key. "
+                            "This URL will be stored as the access link for the dataset instead. "
+                            "We recommend updating your JSONLD using the latest version of the Neurobagel CLI."
+                        )
+                    dataset_attributes[attribute_name] = jsonld_dataset[jsonld_key]
+            datasets_metadata_lookup[dataset_uuid] = dataset_attributes
 
         shutil.copy2(jsonld_path, output_dir)
 

--- a/init_data/process_jsonld.py
+++ b/init_data/process_jsonld.py
@@ -155,10 +155,9 @@ def transform_age(value: str, value_format: str) -> float | None:
         )
     except (ValueError, isodate.isoerror.ISO8601Error) as e:
         logger.error(
-            f"Error applying the format {value_format} to the age value: {value}. Error: {e}\n"
+            f"Error applying the format {value_format} to the age value: '{value}': {e}. "
             f"Check your data dictionary to ensure that the annotated age format matches the age values in your phenotypic table, "
-            "and that any missing values in your age column have been correctly annotated. "
-            "For examples of acceptable values for specific age formats, see https://neurobagel.org/data_models/dictionaries/#age.",
+            "and that any missing values in your age column have been correctly annotated.",
         )
     return None
 
@@ -215,6 +214,7 @@ def get_dataset_level_pheno_attributes(data_dict: dict, dataset_name: str) -> di
         if transformed_min is None or transformed_max is None:
             logger.error(
                 f"Dataset '{dataset_name}': Unable to transform the minimum and/or maximum age values to floats. "
+                "Skipping dataset."
             )
             return None
         summary_pheno_attributes["age_range"] = {
@@ -310,19 +310,15 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
                 continue
 
             # dump dataset description back to dict for easier modification
-            validated_dataset_desc = validated_dataset_desc.model_dump(mode="json")
-            if homepage_url := get_homepage_url(validated_dataset_desc["references_and_links"]):
-                validated_dataset_desc["homepage"] = homepage_url
+            validated_dataset_desc = validated_dataset_desc.model_dump(mode="json", exclude_defaults=True)
+            if "references_and_links" in validated_dataset_desc:
+                if homepage_url := get_homepage_url(validated_dataset_desc["references_and_links"]):
+                    validated_dataset_desc["homepage"] = homepage_url
 
             dataset_name = validated_dataset_desc["dataset_name"]
             dataset_summary_pheno_attributes = get_dataset_level_pheno_attributes(data_dict, dataset_name)
 
             if dataset_summary_pheno_attributes is None:
-                logger.error(
-                    f"Dataset '{dataset_name}': "
-                    "Failed to extract summary phenotypic attributes from the data dictionary. "
-                    "Skipping dataset."
-                )
                 excluded_jsons.extend([dataset_files["description"].name, dataset_files["dictionary"].name])
                 continue
 

--- a/init_data/process_jsonld.py
+++ b/init_data/process_jsonld.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError, TypeAdapter, HttpUrl
 from init_data.utils import models, dataset_description_model
 from collections import defaultdict
 import isodate
+import uuid
 
 NB_CATALOG_MODE = os.environ.get("NB_CATALOG_MODE", "false").lower() == "true"
 DATA_DICTIONARY_SUFFIX = "_annotated.json"
@@ -107,10 +108,6 @@ def get_categorical_annotations_levels(column_annotations: dict) -> list[str]:
     return levels_std_terms
 
 
-def get_is_part_of_assessment(column_annotations: dict) -> str:
-    return column_annotations["IsPartOf"]["TermURL"]
-
-
 def transform_age(value: str, value_format: str) -> float | None:
     """
     Adapted from: https://github.com/neurobagel/bagel-cli/blob/053f9c87e1030392158d0975759c955c24199a3c/bagel/utilities/pheno_utils.py#L226-L259.
@@ -173,7 +170,7 @@ def get_summary_pheno_attributes_for_dataset(data_dict: dict, dataset_name: str)
 
     available_assessments = []
     for assessment_column in get_column_annotations_about(data_dict, "nb:Assessment"):
-        available_assessments.append(get_is_part_of_assessment(assessment_column))
+        available_assessments.append(assessment_column["IsPartOf"]["TermURL"])
     summary_pheno_attributes["available_assessments"] = available_assessments
 
     summary_pheno_attributes = {
@@ -260,12 +257,12 @@ def extract_datasets_metadata_to_dict(jsonld_dir: Path, output_dir: Path) -> dic
                 continue
 
             # dump back to dict
-            # TODO: Rename to 'validated_dataset_desc'?
-            dataset_attributes = validated_dataset_desc.model_dump()
-            if homepage_url := get_homepage_url(dataset_attributes["references_and_links"]):
-                dataset_attributes["homepage"] = homepage_url
+            validated_dataset_desc = validated_dataset_desc.model_dump()
+            if homepage_url := get_homepage_url(validated_dataset_desc["references_and_links"]):
+                validated_dataset_desc["homepage"] = homepage_url
 
-            dataset_name = dataset_attributes["dataset_name"]
+            dataset_name = validated_dataset_desc["dataset_name"]
+            dataset_uuid = "nb:" + str(uuid.uuid4())
             dataset_summary_pheno_attributes = get_summary_pheno_attributes_for_dataset(data_dict, dataset_name)
             if dataset_summary_pheno_attributes is None:
                 logger.error(
@@ -274,8 +271,8 @@ def extract_datasets_metadata_to_dict(jsonld_dir: Path, output_dir: Path) -> dic
                     "Skipping dataset."
                 )
                 continue
-            dataset_attributes = {**dataset_attributes, **dataset_summary_pheno_attributes}
-
+            dataset_attributes =  {**validated_dataset_desc, **dataset_summary_pheno_attributes}
+            datasets_metadata_lookup[dataset_uuid] = dataset_attributes
     else:
         num_input_jsonlds = len(list(jsonld_dir.glob("*.jsonld")))
         for idx, jsonld_path in enumerate(jsonld_dir.glob("*.jsonld"), start=1):
@@ -304,15 +301,15 @@ def extract_datasets_metadata_to_dict(jsonld_dir: Path, output_dir: Path) -> dic
 
         shutil.copy2(jsonld_path, output_dir)
 
-    logger.info(
-        f"Dataset metadata successfully extracted from {len(datasets_metadata_lookup)}/{num_input_jsonlds} JSONLD file(s); "
-        "will upload the file(s) to the graph store."
-    )
-    if excluded_jsonlds:
-        logger.warning(
-            f"The following {len(excluded_jsonlds)} JSONLD file(s) failed validation and will not be uploaded:\n"
-            + '\n'.join(excluded_jsonlds)
+        logger.info(
+            f"Dataset metadata successfully extracted from {len(datasets_metadata_lookup)}/{num_input_jsonlds} JSONLD file(s); "
+            "will upload the file(s) to the graph store."
         )
+        if excluded_jsonlds:
+            logger.warning(
+                f"The following {len(excluded_jsonlds)} JSONLD file(s) failed validation and will not be uploaded:\n"
+                + '\n'.join(excluded_jsonlds)
+            )
     return datasets_metadata_lookup
 
 

--- a/init_data/process_jsonld.py
+++ b/init_data/process_jsonld.py
@@ -285,12 +285,12 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
                 # We do not perform the additional custom multi-column validations done by the CLI
                 # (https://github.com/neurobagel/bagel-cli/blob/053f9c87e1030392158d0975759c955c24199a3c/bagel/utilities/pheno_utils.py#L482)
                 # such as checking that there is only 1 participant/session ID column annotated, etc.
-                dictionary_models.model_validate(data_dict)
+                dictionary_models.DataDictionary.model_validate(data_dict)
             except ValidationError as err:
                 logger.error(
                     f"{dataset_files['dictionary'].name} is not a valid Neurobagel data dictionary.\n"
                     f"Validation errors:\n"
-                    f"{err}",
+                    f"{str(err)}"
                     "\nSkipping dataset."
                 )
                 has_schema_errors = True
@@ -300,7 +300,7 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
                 logger.error(
                     f"{dataset_files['description'].name} is not a valid Neurobagel dataset description.\n"
                     f"Validation errors:\n"
-                    f"{err}",
+                    f"{str(err)}"
                     "\nSkipping dataset."
                 )
                 has_schema_errors = True

--- a/init_data/process_jsonld.py
+++ b/init_data/process_jsonld.py
@@ -7,10 +7,20 @@ import shutil
 from pydantic import ValidationError, TypeAdapter, HttpUrl
 from init_data.utils import models, dataset_description_model
 from collections import defaultdict
+import isodate
 
 NB_CATALOG_MODE = os.environ.get("NB_CATALOG_MODE", "false").lower() == "true"
 DATA_DICTIONARY_SUFFIX = "_annotated.json"
 DATASET_DESCRIPTION_SUFFIX = "_dataset_description.json"
+
+AGE_FORMATS = {
+    "float": "nb:FromFloat",
+    "int": "nb:FromInt",
+    "euro": "nb:FromEuro",
+    "bounded": "nb:FromBounded",
+    "iso8601": "nb:FromISO8601",
+    "range": "nb:FromRange",
+}
 
 logging.basicConfig(
     level=logging.INFO,
@@ -89,6 +99,128 @@ def get_homepage_url(references_and_links: list[str]) -> str | None:
         None
     )
 
+
+def get_all_column_annotations(data_dict: dict) -> list[dict]:
+    return [
+        column_content["Annotations"]
+        for column_content in data_dict.values()
+        if "Annotations" in column_content
+    ]
+
+
+def get_column_annotations_about(data_dict: dict, std_var: str) -> list[dict]:
+    return [
+        column_annotations for column_annotations in get_all_column_annotations(data_dict)
+        if column_annotations["IsAbout"]["TermURL"] == std_var
+    ]
+
+
+def get_categorical_annotations_levels(column_annotations: dict) -> list[str]:
+    levels_std_terms = []
+    for level in column_annotations["Levels"].values():
+        levels_std_terms.append(level["TermURL"])
+    return levels_std_terms
+
+
+def get_is_part_of_assessment(column_annotations: dict) -> str:
+    return column_annotations["IsPartOf"]["TermURL"]
+
+
+def transform_age(value: str, value_format: str) -> float | None:
+    try:
+        if value_format in [
+            AGE_FORMATS["float"],
+            AGE_FORMATS["int"],
+        ]:
+            return float(value)
+        if value_format == AGE_FORMATS["euro"]:
+            return float(value.replace(",", "."))
+        if value_format == AGE_FORMATS["bounded"]:
+            return float(value.strip("+"))
+        if value_format == AGE_FORMATS["iso8601"]:
+            if not value.startswith("P"):
+                pvalue = "P" + value
+            else:
+                pvalue = value
+            duration = isodate.parse_duration(pvalue)
+            return float(duration.years + duration.months / 12)
+        if value_format == AGE_FORMATS["range"]:
+            a_min, a_max = value.split("-")
+            return sum(map(float, [a_min, a_max])) / 2
+        logger.error(
+            f"The data dictionary contains an unrecognized age format: {value_format}. "
+            f"Ensure that the format TermURL is one of {list(AGE_FORMATS.values())}.",
+        )
+    except (ValueError, isodate.isoerror.ISO8601Error) as e:
+        logger.error(
+            f"Error applying the format {value_format} to the age value: {value}. Error: {e}\n"
+            f"Check your data dictionary to ensure that the annotated age format matches the age values in your phenotypic table, "
+            "and that any missing values in your age column have been correctly annotated. "
+            "For examples of acceptable values for specific age formats, see https://neurobagel.org/data_models/dictionaries/#age.",
+        )
+    return None
+
+
+def get_summary_pheno_attributes(data_dict: dict, dataset_name: str) -> dict | None:
+    summary_pheno_attributes = {}
+
+    sex_column_annotations = get_column_annotations_about(data_dict, "nb:Sex")
+    # Keep handling of >1 sex columns consistent with the CLI
+    if len(sex_column_annotations) > 1:
+        logger.warning(
+            f"Dataset '{dataset_name}': The data dictionary indicates more than one column about participant sex, "
+            "which is not currently supported in Neurobagel. "
+            "Only the first of these columns will be used to determine available participant sex."
+        )
+    summary_pheno_attributes["available_sex"] = get_categorical_annotations_levels(
+        sex_column_annotations[0]
+    ) if sex_column_annotations else []
+
+    available_diagnoses = []
+    for diagnosis_column in get_column_annotations_about(data_dict, "nb:Diagnosis"):
+        available_diagnoses.extend(
+            get_categorical_annotations_levels(diagnosis_column)
+        )
+    summary_pheno_attributes["available_diagnoses"] = available_diagnoses
+
+    available_assessments = []
+    for assessment_column in get_column_annotations_about(data_dict, "nb:Assessment"):
+        available_assessments.append(get_is_part_of_assessment(assessment_column))
+    summary_pheno_attributes["available_assessments"] = available_assessments
+
+    summary_pheno_attributes = {
+        variable: list(dict.fromkeys(terms)) for variable, terms in summary_pheno_attributes.items()
+    }
+    
+    # TODO: Handle age
+    age_column_annotations = get_column_annotations_about(data_dict, "nb:Age")
+    if len(age_column_annotations) > 1:
+        logger.warning(
+            f"Dataset '{dataset_name}': The data dictionary indicates more than one column about age, "
+            "which is not currently supported in Neurobagel. "
+            "Only the first of these columns will be used to determine the age range for the dataset."
+        )
+    if age_column_annotations:
+        age_range = age_column_annotations[0]["ValueRange"]
+        age_format = age_column_annotations[0]["Format"]["TermURL"]
+        transformed_min = transform_age(age_range["Minimum"], age_format)
+        transformed_max = transform_age(age_range["Maximum"], age_format)
+        if transformed_min is None or transformed_max is None:
+            logger.error(
+                f"Dataset '{dataset_name}': Unable to transform the minimum and/or maximum age values to floats. "
+            )
+            return None
+
+        summary_pheno_attributes["age_range"] = {
+            "minimum": transformed_min,
+            "maximum": transformed_max,
+        }
+    else:
+        summary_pheno_attributes["age_range"] = None
+
+    return summary_pheno_attributes
+
+
 # TODO: Rename jsonld_dir to data_dir to account for fact that it'll have JSONs as well
 def extract_datasets_metadata_to_dict(jsonld_dir: Path, output_dir: Path) -> dict:
     """
@@ -119,22 +251,41 @@ def extract_datasets_metadata_to_dict(jsonld_dir: Path, output_dir: Path) -> dic
                     missing_file = f"{dataset_file_id}{DATA_DICTIONARY_SUFFIX}"
                 else:
                     missing_file = f"{dataset_file_id}{DATASET_DESCRIPTION_SUFFIX}"
-                logger.warning(
+                logger.error(
                     f"{file}' is missing a corresponding {missing_file}. Skipping dataset."
                 )
                 continue
 
+            # TODO: Validate the data dict
             data_dict = load_json(dataset_files["dictionary"])
             dataset_desc = load_json(dataset_files["description"])
             # TODO: Generate a UUID programmatically
 
-            validated_dataset_desc = dataset_description_model.DatasetDescription.model_validate(dataset_desc)
+            try:
+                validated_dataset_desc = dataset_description_model.DatasetDescription.model_validate(dataset_desc)
+            except ValidationError as err:
+                logger.error(
+                    f"{dataset_files['description']} is not a invalid Neurobagel dataset description. "
+                    "Skipping dataset."
+                    f"\nValidation details:\n"
+                    f"{err}",
+                )
+                continue
 
-            for dataset_description_key in json_key_to_dataset_attribute_mapping:
-                if dataset_description_key in validated_dataset_desc:
-                    if dataset_description_key == "ReferencesAndLinks":
-                        if homepage_url := get_homepage_url(validated_dataset_desc[dataset_description_key]):
-                            dataset_attributes["homepage"] = homepage_url
+            # dump back to dict
+            validated_dataset_desc = validated_dataset_desc.model_dump()
+            dataset_name = validated_dataset_desc["dataset_name"]
+
+            if homepage_url := get_homepage_url(validated_dataset_desc["references_and_links"]):
+                dataset_attributes["homepage"] = homepage_url
+            
+            dataset_summary_pheno_attributes = get_summary_pheno_attributes(data_dict, dataset_name)
+            if dataset_summary_pheno_attributes is None:
+                logger.error(
+                    f"Dataset '{dataset_name}': Unable to extract summary phenotypic attributes from the data dictionary. Skipping dataset."
+                )
+                continue
+            dataset_attributes = {**validated_dataset_desc, **dataset_summary_pheno_attributes}
 
     else:
         num_input_jsonlds = len(list(jsonld_dir.glob("*.jsonld")))

--- a/init_data/process_jsonld.py
+++ b/init_data/process_jsonld.py
@@ -256,7 +256,7 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
                 dataset_json_file_groups[dataset_id]["description"] = json_file
             else:
                 logger.warning(
-                    f"JSON file {json_file.name} does not have the expected suffix "
+                    f"{json_file.name} does not have the expected suffix "
                     f"for a data dictionary ({DATA_DICTIONARY_SUFFIX}) "
                     f"or a dataset description ({DATASET_DESCRIPTION_SUFFIX}). "
                     "Skipping file."
@@ -310,7 +310,7 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
                 continue
 
             # dump dataset description back to dict for easier modification
-            validated_dataset_desc = validated_dataset_desc.model_dump()
+            validated_dataset_desc = validated_dataset_desc.model_dump(mode="json")
             if homepage_url := get_homepage_url(validated_dataset_desc["references_and_links"]):
                 validated_dataset_desc["homepage"] = homepage_url
 
@@ -329,10 +329,10 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
             dataset_attributes =  {**validated_dataset_desc, **dataset_summary_pheno_attributes}
             dataset_uuid = "nb:" + str(uuid.uuid4())
             datasets_metadata_lookup[dataset_uuid] = dataset_attributes
-            logger.info(f"Successfully catalogued dataset: {dataset_name}")
+            logger.info(f"Successfully catalogued dataset: '{dataset_name}'")
 
         logger.info(
-            f"Dataset catalog metadata successfully extracted from {len(datasets_metadata_lookup)} datasets. "
+            f"Dataset catalog metadata successfully extracted from {len(datasets_metadata_lookup)} dataset(s). "
         )
         if excluded_jsons:
             logger.warning(

--- a/init_data/process_jsonld.py
+++ b/init_data/process_jsonld.py
@@ -9,6 +9,7 @@ from init_data.utils import models, dictionary_models, dataset_description_model
 from collections import defaultdict
 import isodate
 import uuid
+import sys
 
 NB_CATALOG_MODE = os.environ.get("NB_CATALOG_MODE", "false").lower() == "true"
 DATA_DICTIONARY_SUFFIX = "_annotated.json"
@@ -43,6 +44,17 @@ jsonld_key_to_dataset_attribute_mapping = {
     "hasAccessLink": "access_link",
     "hasPortalURI": "access_link",  # Map legacy hasPortalURI to access_link
 }
+
+
+def list_files_with_extension(input_dir: Path, extension: str) -> list[Path]:
+    file_list = list(input_dir.glob(f"*{extension}"))
+    if not file_list:
+        logger.error(
+            f"No {extension} files found in the data directory. "
+            f"Ensure that your dataset {extension} files are located in the directory specified by LOCAL_GRAPH_DATA, "
+            "and that you have correctly set NB_CATALOG_MODE."
+        )
+    return file_list
 
 
 def load_json(path: Path) -> dict:
@@ -228,9 +240,14 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
     datasets_metadata_lookup = {}
 
     if NB_CATALOG_MODE:
+        logger.info("Initializing node data in catalog mode.")
+        input_jsons = list_files_with_extension(data_files_dir, ".json")
+        if not input_jsons:
+            sys.exit(1)
+
         dataset_json_file_groups = defaultdict(dict)
         excluded_jsons = []
-        for json_file in data_files_dir.glob("*.json"):
+        for json_file in input_jsons:
             if json_file.name.endswith(DATA_DICTIONARY_SUFFIX):
                 dataset_id = json_file.name.removesuffix(DATA_DICTIONARY_SUFFIX)
                 dataset_json_file_groups[dataset_id]["dictionary"] = json_file
@@ -322,9 +339,14 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
                 f"Skipped {len(excluded_jsons)} JSON files:\n" + "\n".join(excluded_jsons)
             )
     else:
-        num_input_jsonlds = len(list(data_files_dir.glob("*.jsonld")))
+        logger.info("Initializing node data in subject-level mode.")
+        input_jsonlds = list_files_with_extension(data_files_dir, ".jsonld")
+        num_input_jsonlds = len(input_jsonlds)
+        if not input_jsonlds:
+            sys.exit(1)
+
         excluded_jsonlds = []
-        for idx, jsonld_path in enumerate(data_files_dir.glob("*.jsonld"), start=1):
+        for idx, jsonld_path in enumerate(input_jsonlds, start=1):
             filename = jsonld_path.name
             logger.info(f"({idx}/{num_input_jsonlds}) Processing file: {filename}")
             jsonld_dataset = load_and_validate_jsonld_dataset(jsonld_path)
@@ -347,8 +369,7 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
                         )
                     dataset_attributes[attribute_name] = jsonld_dataset[jsonld_key]
             datasets_metadata_lookup[dataset_uuid] = dataset_attributes
-
-        shutil.copy2(jsonld_path, output_dir)
+            shutil.copy2(jsonld_path, output_dir)
 
         logger.info(
             f"Dataset metadata successfully extracted from {len(datasets_metadata_lookup)}/{num_input_jsonlds} JSONLD file(s); "

--- a/init_data/process_jsonld.py
+++ b/init_data/process_jsonld.py
@@ -5,7 +5,7 @@ import logging
 import argparse
 import shutil
 from pydantic import ValidationError, TypeAdapter, HttpUrl
-from init_data.utils import models, dataset_description_model
+from init_data.utils import models, dictionary_models, dataset_description_model
 from collections import defaultdict
 import isodate
 import uuid
@@ -260,29 +260,42 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
                 skipped_json_files.append(file.name)
                 continue
 
-            # TODO: Validate the data dict
             data_dict = load_json(dataset_files["dictionary"])
             dataset_desc = load_json(dataset_files["description"])
+            has_schema_errors = False
+            try:
+                dictionary_models.model_validate(data_dict)
+            except ValidationError as err:
+                logger.error(
+                    f"{dataset_files['dictionary'].name} is not a valid Neurobagel data dictionary.\n"
+                    f"Validation errors:\n"
+                    f"{err}",
+                    "\nSkipping dataset."
+                )
+                has_schema_errors = True
             try:
                 validated_dataset_desc = dataset_description_model.DatasetDescription.model_validate(dataset_desc)
             except ValidationError as err:
                 logger.error(
-                    f"{dataset_files['description'].name} is not a valid Neurobagel dataset description. "
-                    "Skipping dataset."
-                    f"\nValidation details:\n"
+                    f"{dataset_files['description'].name} is not a valid Neurobagel dataset description.\n"
+                    f"Validation errors:\n"
                     f"{err}",
+                    "\nSkipping dataset."
                 )
+                has_schema_errors = True
+
+            if has_schema_errors:
                 skipped_json_files.extend([dataset_files["description"].name, dataset_files["dictionary"].name])
                 continue
 
-            # dump back to dict
+            # dump dataset description back to dict for easier modification
             validated_dataset_desc = validated_dataset_desc.model_dump()
             if homepage_url := get_homepage_url(validated_dataset_desc["references_and_links"]):
                 validated_dataset_desc["homepage"] = homepage_url
 
             dataset_name = validated_dataset_desc["dataset_name"]
-            dataset_uuid = "nb:" + str(uuid.uuid4())
             dataset_summary_pheno_attributes = get_dataset_level_pheno_attributes(data_dict, dataset_name)
+
             if dataset_summary_pheno_attributes is None:
                 logger.error(
                     f"Dataset '{dataset_name}': "
@@ -291,9 +304,11 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
                 )
                 skipped_json_files.extend([dataset_files["description"].name, dataset_files["dictionary"].name])
                 continue
+
             dataset_attributes =  {**validated_dataset_desc, **dataset_summary_pheno_attributes}
+            dataset_uuid = "nb:" + str(uuid.uuid4())
             datasets_metadata_lookup[dataset_uuid] = dataset_attributes
-        
+
         logger.info(
             f"Dataset metadata successfully parsed from {len(datasets_metadata_lookup)} datasets for catalog mode. "
             f"Excluded {len(skipped_json_files)} JSON files:\n" + "\n".join(skipped_json_files)

--- a/init_data/process_jsonld.py
+++ b/init_data/process_jsonld.py
@@ -226,11 +226,10 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
     A dictionary mapping dataset UUIDs to their metadata is returned.
     """    
     datasets_metadata_lookup = {}
-    excluded_jsonlds = []
 
     if NB_CATALOG_MODE:
         dataset_json_file_groups = defaultdict(dict)
-        skipped_json_files = []
+        excluded_jsons = []
         for json_file in data_files_dir.glob("*.json"):
             if json_file.name.endswith(DATA_DICTIONARY_SUFFIX):
                 dataset_id = json_file.name.removesuffix(DATA_DICTIONARY_SUFFIX)
@@ -245,7 +244,7 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
                     f"or a dataset description ({DATASET_DESCRIPTION_SUFFIX}). "
                     "Skipping file."
                 )
-                skipped_json_files.append(json_file.name)
+                excluded_jsons.append(json_file.name)
 
         for dataset_file_id, dataset_files in dataset_json_file_groups.items():
             if "dictionary" not in dataset_files or "description" not in dataset_files:
@@ -257,7 +256,7 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
                 logger.error(
                     f"{file.name} is missing a corresponding {missing_file}. Skipping dataset."
                 )
-                skipped_json_files.append(file.name)
+                excluded_jsons.append(file.name)
                 continue
 
             data_dict = load_json(dataset_files["dictionary"])
@@ -285,7 +284,7 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
                 has_schema_errors = True
 
             if has_schema_errors:
-                skipped_json_files.extend([dataset_files["description"].name, dataset_files["dictionary"].name])
+                excluded_jsons.extend([dataset_files["description"].name, dataset_files["dictionary"].name])
                 continue
 
             # dump dataset description back to dict for easier modification
@@ -302,19 +301,24 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
                     "Failed to extract summary phenotypic attributes from the data dictionary. "
                     "Skipping dataset."
                 )
-                skipped_json_files.extend([dataset_files["description"].name, dataset_files["dictionary"].name])
+                excluded_jsons.extend([dataset_files["description"].name, dataset_files["dictionary"].name])
                 continue
 
             dataset_attributes =  {**validated_dataset_desc, **dataset_summary_pheno_attributes}
             dataset_uuid = "nb:" + str(uuid.uuid4())
             datasets_metadata_lookup[dataset_uuid] = dataset_attributes
+            logger.info(f"Successfully catalogued dataset: {dataset_name}")
 
         logger.info(
-            f"Dataset metadata successfully parsed from {len(datasets_metadata_lookup)} datasets for catalog mode. "
-            f"Excluded {len(skipped_json_files)} JSON files:\n" + "\n".join(skipped_json_files)
+            f"Dataset catalog metadata successfully extracted from {len(datasets_metadata_lookup)} datasets. "
         )
+        if excluded_jsons:
+            logger.warning(
+                f"Skipped {len(excluded_jsons)} JSON files:\n" + "\n".join(excluded_jsons)
+            )
     else:
         num_input_jsonlds = len(list(data_files_dir.glob("*.jsonld")))
+        excluded_jsonlds = []
         for idx, jsonld_path in enumerate(data_files_dir.glob("*.jsonld"), start=1):
             filename = jsonld_path.name
             logger.info(f"({idx}/{num_input_jsonlds}) Processing file: {filename}")
@@ -350,6 +354,7 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
                 f"The following {len(excluded_jsonlds)} JSONLD file(s) failed validation and will not be uploaded:\n"
                 + '\n'.join(excluded_jsonlds)
             )
+
     return datasets_metadata_lookup
 
 

--- a/init_data/process_jsonld.py
+++ b/init_data/process_jsonld.py
@@ -263,6 +263,11 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
             dataset_desc = load_json(dataset_files["description"])
             has_schema_errors = False
             try:
+                # NOTE: Here we only do a basic schema-based validation that ensures that
+                # column annotations are correctly structured in the data dictionary.
+                # We do not perform the additional custom multi-column validations done by the CLI
+                # (https://github.com/neurobagel/bagel-cli/blob/053f9c87e1030392158d0975759c955c24199a3c/bagel/utilities/pheno_utils.py#L482)
+                # such as checking that there is only 1 participant/session ID column annotated, etc.
                 dictionary_models.model_validate(data_dict)
             except ValidationError as err:
                 logger.error(

--- a/init_data/process_jsonld.py
+++ b/init_data/process_jsonld.py
@@ -213,8 +213,10 @@ def get_dataset_level_pheno_attributes(data_dict: dict, dataset_name: str) -> di
     if age_column_annotations:
         age_range = age_column_annotations[0]["ValueRange"]
         age_format = age_column_annotations[0]["Format"]["TermURL"]
-        transformed_min = transform_age(age_range["Minimum"], age_format)
-        transformed_max = transform_age(age_range["Maximum"], age_format)
+        raw_min = age_range["Minimum"]
+        raw_max = age_range["Maximum"]
+        transformed_min = transform_age(raw_min, age_format)
+        transformed_max = transform_age(raw_max, age_format)
         if transformed_min is None or transformed_max is None:
             logger.error(
                 f"Dataset '{dataset_name}': Unable to transform the minimum and/or maximum age values to floats. "
@@ -267,13 +269,16 @@ def extract_datasets_metadata_to_dict(data_files_dir: Path, output_dir: Path) ->
                 )
                 excluded_jsons.append(json_file.name)
 
+        # Determine if there are any dataset description or data dictionary files without the corresponding paired file,
+        # to log an informative error message and skip those files
         for dataset_file_id, dataset_files in dataset_json_file_groups.items():
             if "dictionary" not in dataset_files or "description" not in dataset_files:
-                file = dataset_files.get("dictionary") or dataset_files.get("description")
                 if "dictionary" not in dataset_files:
                     missing_file = f"{dataset_file_id}{DATA_DICTIONARY_SUFFIX}"
+                    file = dataset_files["description"]
                 else:
                     missing_file = f"{dataset_file_id}{DATASET_DESCRIPTION_SUFFIX}"
+                    file = dataset_files["dictionary"]
                 logger.error(
                     f"{file.name} is missing a corresponding {missing_file}. "
                     "Ensure that the data dictionary and dataset description files for the dataset have the same prefix. "

--- a/init_data/requirements.txt
+++ b/init_data/requirements.txt
@@ -1,2 +1,3 @@
+isodate
 pydantic>=2.12,<3
 email-validator

--- a/init_data/utils/dataset_description_model.py
+++ b/init_data/utils/dataset_description_model.py
@@ -1,0 +1,139 @@
+from enum import Enum
+from typing import Annotated, Any
+
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    EmailStr,
+    Field,
+    HttpUrl,
+    field_validator,
+)
+
+
+def whitespace_string_to_default_none(value: Any) -> Any:
+    """Convert an empty string or a string that contains only whitespace to None."""
+    if isinstance(value, str) and value.strip() == "":
+        return None
+    return value
+
+
+class AccessType(str, Enum):
+    """Enum for dataset access type."""
+
+    PUBLIC = "public"
+    REGISTERED = "registered"
+    RESTRICTED = "restricted"
+
+
+class DatasetDescription(BaseModel):
+    """Schema for a Neurobagel dataset description JSON file."""
+
+    name: Annotated[
+        str,
+        Field(
+            ...,
+            description=(
+                "Name of the dataset. This name will be displayed when users discover the dataset in a Neurobagel query. "
+                "Key reused from BIDS dataset_description.json."
+            ),
+            alias="Name",
+        ),
+    ]
+    authors: Annotated[
+        list[str],
+        Field(
+            default_factory=list,
+            description="List of individuals who contributed to the creation/curation of the dataset. Key reused from BIDS dataset_description.json.",
+            alias="Authors",
+        ),
+    ]
+    # NOTE: In the BIDS dataset_description.json, values for this field can be string references as well as URLs.
+    references_and_links: Annotated[
+        list[str],
+        Field(
+            default_factory=list,
+            description="List of links or references that contain information on the dataset. Key reused from BIDS dataset_description.json.",
+            alias="ReferencesAndLinks",
+        ),
+    ]
+    keywords: Annotated[
+        list[str],
+        Field(
+            default_factory=list,
+            description="List of keywords describing the content or subject matter of the dataset. Key reused from BIDS dataset_description.json.",
+            alias="Keywords",
+        ),
+    ]
+    repository_url: Annotated[
+        HttpUrl | None,
+        Field(
+            default=None,
+            description="URL to a repository where the dataset can be downloaded or retrieved from (e.g., DataLad, Zenodo, GitHub).",
+            alias="RepositoryURL",
+        ),
+        BeforeValidator(whitespace_string_to_default_none),
+    ]
+    access_instructions: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description="Description of how to access the data.",
+            alias="AccessInstructions",
+        ),
+        AfterValidator(whitespace_string_to_default_none),
+    ]
+    access_type: Annotated[
+        AccessType,
+        Field(
+            default=None,
+            description="Level of requirements for dataset access.",
+            alias="AccessType",
+        ),
+    ]
+    access_email: Annotated[
+        EmailStr | None,
+        Field(
+            default=None,
+            description="Primary email for access requests.",
+            alias="AccessEmail",
+        ),
+        BeforeValidator(whitespace_string_to_default_none),
+    ]
+    access_link: Annotated[
+        HttpUrl | None,
+        Field(
+            default=None,
+            description="Primary link for access requests or information.",
+            alias="AccessLink",
+        ),
+        BeforeValidator(whitespace_string_to_default_none),
+    ]
+
+    # NOTE: url_preserve_empty_path (>=2.12) is needed to prevent HttpUrl from auto-appending trailing slashes to URLs
+    # when the path portion of the URL is empty
+    # (https://docs.pydantic.dev/latest/migration/#url-and-dsn-types-in-pydanticnetworks-no-longer-inherit-from-str)
+    model_config = ConfigDict(extra="ignore", url_preserve_empty_path=True)
+
+    @field_validator("name")
+    @classmethod
+    def check_name_not_whitespace(cls, value: str) -> str:
+        """
+        Raise an error (will be caught as a ValidationError by Pydantic) if
+        the required 'Name' field is an empty string or all whitespace.
+        """
+        if value.strip() == "":
+            raise ValueError("'Name' field cannot be an empty string.")
+        return value
+
+    @field_validator("authors", "references_and_links", "keywords")
+    @classmethod
+    def whitespace_list_to_default_empty_list(
+        cls, value: list[str]
+    ) -> list[str]:
+        """Convert a list containing only empty or whitespace strings to an empty list."""
+        if all(item.strip() == "" for item in value):
+            return []
+        return value

--- a/init_data/utils/dataset_description_model.py
+++ b/init_data/utils/dataset_description_model.py
@@ -130,7 +130,7 @@ class DatasetDescription(BaseModel):
     # (https://docs.pydantic.dev/latest/migration/#url-and-dsn-types-in-pydanticnetworks-no-longer-inherit-from-str)
     model_config = ConfigDict(extra="ignore", url_preserve_empty_path=True)
 
-    @field_validator("name")
+    @field_validator("dataset_name")
     @classmethod
     def check_name_not_whitespace(cls, value: str) -> str:
         """

--- a/init_data/utils/dataset_description_model.py
+++ b/init_data/utils/dataset_description_model.py
@@ -1,3 +1,7 @@
+# This file is adapted from https://github.com/neurobagel/bagel-cli/blob/main/bagel/dataset_description_model.py
+# but is modified to include a required "participant_count" field,
+# which is only used for the Neurobagel catalog node mode.
+
 from enum import Enum
 from typing import Annotated, Any
 
@@ -48,6 +52,14 @@ class DatasetDescription(BaseModel):
             default_factory=list,
             description="List of individuals who contributed to the creation/curation of the dataset. Key reused from BIDS dataset_description.json.",
             alias="Authors",
+        ),
+    ]
+    participant_count: Annotated[
+        int,
+        Field(
+            ...,
+            description="Number of participants in the dataset.",
+            alias="ParticipantCount",
         ),
     ]
     # NOTE: In the BIDS dataset_description.json, values for this field can be string references as well as URLs.

--- a/init_data/utils/dataset_description_model.py
+++ b/init_data/utils/dataset_description_model.py
@@ -1,4 +1,4 @@
-# This file is adapted from https://github.com/neurobagel/bagel-cli/blob/main/bagel/dataset_description_model.py
+# This file is adapted from https://github.com/neurobagel/bagel-cli/blob/053f9c87e1030392158d0975759c955c24199a3c/bagel/dataset_description_model.py
 # but is modified to include a required "participant_count" field,
 # (which is only used for the Neurobagel catalog node mode)
 # and to rename the "name" field to "dataset_name" for the purposes of the internal datasets metadata file.

--- a/init_data/utils/dataset_description_model.py
+++ b/init_data/utils/dataset_description_model.py
@@ -1,6 +1,7 @@
 # This file is adapted from https://github.com/neurobagel/bagel-cli/blob/main/bagel/dataset_description_model.py
 # but is modified to include a required "participant_count" field,
-# which is only used for the Neurobagel catalog node mode.
+# (which is only used for the Neurobagel catalog node mode)
+# and to rename the "name" field to "dataset_name" for the purposes of the internal datasets metadata file.
 
 from enum import Enum
 from typing import Annotated, Any
@@ -35,7 +36,7 @@ class AccessType(str, Enum):
 class DatasetDescription(BaseModel):
     """Schema for a Neurobagel dataset description JSON file."""
 
-    name: Annotated[
+    dataset_name: Annotated[
         str,
         Field(
             ...,

--- a/init_data/utils/dataset_description_model.py
+++ b/init_data/utils/dataset_description_model.py
@@ -15,6 +15,7 @@ from pydantic import (
     Field,
     HttpUrl,
     field_validator,
+    PositiveInt,
 )
 
 
@@ -56,7 +57,7 @@ class DatasetDescription(BaseModel):
         ),
     ]
     participant_count: Annotated[
-        int,
+        PositiveInt,  # strictly >0
         Field(
             ...,
             description="Number of participants in the dataset.",

--- a/init_data/utils/dictionary_models.py
+++ b/init_data/utils/dictionary_models.py
@@ -1,0 +1,243 @@
+# Adapted from https://github.com/neurobagel/bagel-cli/blob/053f9c87e1030392158d0975759c955c24199a3c/bagel/dictionary_models.py
+# but with the addition of a Range class and valueRange field for continuous annotated columns.
+from typing import Annotated, Literal
+
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+)
+from pydantic_core import PydanticCustomError
+
+
+def validate_unique_list(values: list[str]) -> list[str]:
+    """
+    Check that provided list only has unique elements.
+
+    This custom validator is needed because constrained dtypes and their `unique_items` parameter
+    were deprecated in Pydantic v2. This function was adapted from https://github.com/pydantic/pydantic-core/pull/820#issuecomment-1656228704
+    and https://docs.pydantic.dev/latest/concepts/validators/#annotated-validators.
+
+    See also:
+    - https://docs.pydantic.dev/latest/migration/#changes-to-pydanticfield
+    - https://docs.pydantic.dev/latest/api/types/#pydantic.types.conlist)
+    """
+    if len(values) != len(set(values)):
+        raise PydanticCustomError(
+            "unique_list", f"{values} is not a unique list"
+        )
+    return values
+
+
+class Term(BaseModel):
+    """An identifier of a controlled term with an IRI"""
+
+    termURL: Annotated[
+        str,
+        Field(
+            ...,
+            description="An unambiguous identifier for the term, concept or entity that is referenced",
+            alias="TermURL",
+        ),
+    ]
+    label: Annotated[
+        str,
+        Field(
+            ...,
+            description="A human readable label. If more than one label exists for the term, "
+            "then the preferred label should be used.",
+            alias="Label",
+        ),
+    ]
+
+
+class Range(BaseModel):
+    """A range of numerical values with minimum and maximum bounds provided as strings."""
+
+    minimum: Annotated[
+        str,
+        Field(
+            ...,
+            description="The minimum value in the range, inclusive.",
+            alias="Minimum",
+        ),
+    ]
+    maximum: Annotated[
+        str,
+        Field(
+            ...,
+            description="The maximum value in the range, inclusive.",
+            alias="Maximum",
+        ),
+    ]
+
+
+class Neurobagel(BaseModel):
+    """The base model for a Neurobagel column annotation"""
+
+    isAbout: Annotated[
+        Term,
+        Field(
+            ...,
+            description="The concept or controlled term that describes this column",
+            alias="IsAbout",
+        ),
+    ]
+    missingValues: Annotated[
+        list[str],
+        AfterValidator(validate_unique_list),
+        Field(
+            [],
+            description="A list of unique values that represent "
+            "invalid responses, typos, or missing data",
+            alias="MissingValues",
+            json_schema_extra={"uniqueItems": True},
+        ),
+    ]
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class IdentifierNeurobagel(BaseModel):
+    """A Neurobagel annotation for an identifier column"""
+
+    isAbout: Annotated[
+        Term,
+        Field(
+            ...,
+            description="The concept or controlled term that describes this column",
+            alias="IsAbout",
+        ),
+    ]
+    variableType: Annotated[
+        Literal["Identifier"], Field(..., alias="VariableType")
+    ]
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class CategoricalNeurobagel(Neurobagel):
+    """A Neurobagel annotation for a categorical column"""
+
+    levels: Annotated[
+        dict[str, Term],
+        Field(
+            ...,
+            description="For categorical variables: "
+            "An object of values (keys) in the column and the semantic "
+            "term (URI and label) they are unambiguously mapped to.",
+            alias="Levels",
+        ),
+    ]
+    variableType: Annotated[
+        Literal["Categorical"], Field(..., alias="VariableType")
+    ]
+
+
+class ContinuousNeurobagel(Neurobagel):
+    """A Neurobagel annotation for a continuous column"""
+
+    format: Annotated[
+        Term,
+        Field(
+            ...,
+            description="For continuous columns this field is used to describe "
+            "the format of the raw numerical values in the column. This information is used to transform "
+            "the column values into the desired format of the standardized "
+            "data element referenced in the IsAbout attribute.",
+            alias="Format",
+        ),
+    ]
+    valueRange: Annotated[
+        Range,
+        Field(
+            ...,
+            description="The range of available values for the continuous column.",
+            alias="ValueRange",
+        ),
+    ]
+    variableType: Annotated[
+        Literal["Continuous"], Field(..., alias="VariableType")
+    ]
+
+
+class CollectionNeurobagel(Neurobagel):
+    """
+    A Neurobagel annotation for a column that is part of a grouped collection of columns,
+    such as items from an instrument.
+    """
+
+    isPartOf: Annotated[
+        Term,
+        Field(
+            ...,
+            description="If the column is a subscale or item of an assessment tool "
+            "then the assessment tool should be specified here.",
+            alias="IsPartOf",
+        ),
+    ]
+    variableType: Annotated[
+        Literal["Collection"], Field(..., alias="VariableType")
+    ]
+
+
+class Column(BaseModel):
+    """The base model for a BIDS column description"""
+
+    # TODO: Revisit if we want to make description an optional field, since we don't currently use it in the graph data.
+    # At the moment, the key itself is always required and the value can be an empty string "",
+    # but a value of null ("Description": null) is invalid and will result in a schema validation error.
+    description: Annotated[
+        str,
+        Field(
+            ...,
+            description="Free-form natural language description",
+            alias="Description",
+        ),
+    ]
+    annotations: Annotated[
+        CategoricalNeurobagel
+        | ContinuousNeurobagel
+        | IdentifierNeurobagel
+        | CollectionNeurobagel,
+        Field(None, description="Semantic annotations", alias="Annotations"),
+    ]
+
+
+class CategoricalColumn(Column):
+    """A BIDS column annotation for a categorical column"""
+
+    levels: Annotated[
+        dict[str, str],
+        Field(
+            ...,
+            description="For categorical variables: "
+            "An object of possible values (keys) "
+            "and their descriptions (values). ",
+            alias="Levels",
+        ),
+    ]
+
+
+class ContinuousColumn(Column):
+    """A BIDS column annotation for a continuous column"""
+
+    units: Annotated[
+        str,
+        Field(
+            ...,
+            description="Measurement units for the values in this column. "
+            "SI units in CMIXF formatting are RECOMMENDED (see Units)",
+            alias="Units",
+        ),
+    ]
+
+
+class DataDictionary(
+    RootModel[dict[str, Column | ContinuousColumn | CategoricalColumn]]
+):
+    """A data dictionary with human and machine readable information for a tabular data file"""
+
+    pass


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #197
- See also https://github.com/neurobagel/recipes/issues/200, https://github.com/neurobagel/recipes/issues/198

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Add new boolean env var `NB_CATALOG_MODE` (default=false) to n-API and `init_data` Docker Compose services
- Update `init_data` to group, parse, & validate pairs of dataset JSON files (`_annotated.json` and `_dataset_description.json`) based on a common prefix
- Convert min & max age from data dict to floats
- Extract & add `available_assessments`, `available_sex`, `available_diagnoses`, and `age_range` keys to output `dataset_metadata.json` file
- Error out & exclude dataset/file if:
  - input file validation fails
  - min or max age cannot be converted to float

Example output `datasets_metadata.json`:
```json
{
  "nb:18532368-82dc-42ac-b4fb-fbb187ad6ae1": {
    "dataset_name": "BIDS synthetic",
    "authors": [
      "Markiewicz, C. J.",
      "Gau, Rémi"
    ],
    "participant_count": 5,
    "references_and_links": [
      "https://bids-website.readthedocs.io/en/latest/datasets/examples.html#mri"
    ],
    "keywords": [
      "synthetic",
      "nback"
    ],
    "repository_url": "https://github.com/bids-standard/bids-examples.git",
    "access_instructions": "Clone the git repository. The dataset is located in the 'synthetic' subdirectory.",
    "access_type": "public",
    "access_email": "bids.curator@gmail.com",
    "access_link": "https://github.com/bids-standard/bids-examples.git",
    "homepage": "https://bids-website.readthedocs.io/en/latest/datasets/examples.html#mri",
    "available_sex": [
      "snomed:248153007",
      "snomed:248152002"
    ],
    "available_diagnoses": [
      "snomed:406506008",
      "ncit:C94342"
    ],
    "available_assessments": [
      "snomed:859351000000102",
      "snomed:342061000000106"
    ],
    "age_range": {
      "minimum": 21.0,
      "maximum": 42.0
    }
  }
}
```

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [ ] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
